### PR TITLE
fix scroll to comments

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+    es6: true,
+  },
+  extends: [
+  ],
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
+  rules: {
+    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'max-len': [0, 190, 4],
+    'linebreak-style': [0, 'windows'],
+    'no-underscore-dangle': 'off',
+    'one-var-declaration-per-line': 'off',
+    'one-var': 'off',
+    'no-use-before-define': 'off',
+    'no-param-reassign': ['error', { "props": false }],
+    'no-else-return': 'off',
+    'object-curly-newline': 'off',
+    "import/no-named-as-default": 0,
+    "prefer-destructuring": ["error", {"object": true, "array": false}]
+  },
+  overrides: [
+    {
+      files: [
+        '**/__tests__/*.{j,t}s?(x)',
+      ],
+      env: {
+        jest: true,
+      },
+    },
+  ],
+};

--- a/spa/src/components/organisms/Comments.vue
+++ b/spa/src/components/organisms/Comments.vue
@@ -59,6 +59,8 @@ export default {
         setTimeout(() => {
           this.$scrollTo(document.getElementById(this.addedId), 500, { easing: 'ease' });
         }, 700);
+      } else {
+        this.scrollToComment();
       }
     },
     itemId() {
@@ -67,16 +69,6 @@ export default {
   },
   created() {
     this.getComments();
-  },
-  mounted() {
-    this.$nextTick(() => {
-      // TODO not reliable. When I click from home, it does not scroll well. When I reload, it scrolls correctly
-      let { hash } = this.$route;
-      if (hash) {
-        hash = hash.substring(1);
-        this.$scrollTo(document.getElementById('comments'), 500, { easing: 'ease' });
-      }
-    });
   },
   destroyed() {
     this.$store.commit('DESTROY_COMMENTS');
@@ -94,6 +86,16 @@ export default {
         payload.lastSeen = this.comments[this.comments.length - 1]._id;
       }
       this.$store.dispatch('FETCH_COMMENTS', payload);
+    },
+    scrollToComment() {
+      let { hash } = this.$route;
+
+      if (hash) {
+        hash = hash.substring(1);
+        setTimeout(() => {
+          this.$scrollTo(document.getElementById(hash), 500, { easing: 'ease' });
+        }, 1);
+      }
     },
   },
 };

--- a/spa/src/views/item/Blog.vue
+++ b/spa/src/views/item/Blog.vue
@@ -109,8 +109,17 @@ export default {
     this.$store.dispatch('FETCH_BLOG', { slug: this.slug });
   },
   mounted() {
+    document.onmouseover = () => {
+      window.innerDocClick = true;
+    };
+    document.onmouseleave = () => {
+      window.innerDocClick = false;
+    };
+
     window.onpopstate = () => {
-      this.$store.commit('CLEAR_BLOG');
+      if (!window.innerDocClick) {
+        this.$store.commit('CLEAR_BLOG');
+      }
     };
   },
   methods: {


### PR DESCRIPTION
Mostly fixed. But if a comment does not get returned from the backend due to not loading all comments at once, the page is not scrolled to it since it doesn't exist in DOM and will get a warning in the developer console. Making the scroll to method work in that situation would require changing the way how comments are fetched. I want your input on this since it would take more than the allotted 3 hours and I don't want to waste time spending anything you don't want me to do.